### PR TITLE
Fixes couple of issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC=c99
-CFLAGS=-c -O2 -Wall -Wextra -D_GNU_SOURCE
+CC=cc
+CFLAGS=-c -O2 -Wall -Wextra -D_GNU_SOURCE --std=c99
 LDFLAGS= -ludev
 SOURCES=$(wildcard *.c)
 HEADERS=$(wildcard *.h)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=c99
-CFLAGS=-c -O -Wall -Wextra -D_GNU_SOURCE
+CFLAGS=-c -O2 -Wall -Wextra -D_GNU_SOURCE
 LDFLAGS= -ludev
 SOURCES=$(wildcard *.c)
 HEADERS=$(wildcard *.h)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=cc
-CFLAGS=-c -O2 -Wall -Wextra -D_GNU_SOURCE --std=c99
+CFLAGS=-c -O2 -Wall -Wextra -D_GNU_SOURCE --std=c11
 LDFLAGS= -ludev
 SOURCES=$(wildcard *.c)
 HEADERS=$(wildcard *.h)

--- a/event_loop.c
+++ b/event_loop.c
@@ -183,6 +183,7 @@ static int do_event_loop(struct udev_monitor *udev_mon, const struct timeval *ti
             /* Device disconected or error */
             if (idevs[i].revents & (POLLHUP | POLLERR | POLLNVAL)){ 
                 free_pos--;
+                close(idevs[i].fd);
                 idevs[i].fd = idevs[free_pos].fd;
                 idevs[i].revents = idevs[free_pos].revents;
             }


### PR DESCRIPTION
Changing the optimization level to -O2 removes the segfault in debian 11 (also for -O0 and -O3), for some reason libudev doesn't like that add_device() calls the same open() inside open_device(), if open_device() is inlined it works. Funy thing, it fails even if add_device() is not called at all.

This PR also fixes a file descriptor leak each time a device is removed

We also remove the c99 alias and updated the C standard

Fixes #8 and #12 
